### PR TITLE
Fix stack problem

### DIFF
--- a/IteratorTools.xcodeproj/project.pbxproj
+++ b/IteratorTools.xcodeproj/project.pbxproj
@@ -51,7 +51,7 @@
 /* Begin PBXFileReference section */
 		897776D01F54784E00D21FD5 /* Combinations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Combinations.swift; path = Sources/Combinations.swift; sourceTree = "<group>"; };
 		897776D41F547B6800D21FD5 /* CombinationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombinationsTests.swift; sourceTree = "<group>"; };
-		89B410991FDF68A7001D86E5 /* AnyIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyIterator.swift; sourceTree = "<group>"; };
+		89B410991FDF68A7001D86E5 /* AnyIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AnyIterator.swift; path = Sources/AnyIterator.swift; sourceTree = "<group>"; };
 		89CEDB5E1F50942D005944DD /* Compress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Compress.swift; path = Sources/Compress.swift; sourceTree = "<group>"; };
 		89CEDB601F509651005944DD /* CompressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompressTests.swift; sourceTree = "<group>"; };
 		89CEDB621F509B27005944DD /* Reject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reject.swift; path = Sources/Reject.swift; sourceTree = "<group>"; };

--- a/IteratorToolsTests/CombinationsTests.swift
+++ b/IteratorToolsTests/CombinationsTests.swift
@@ -62,6 +62,15 @@ class CombinationsWithoutRepetitionTests: XCTestCase {
         XCTAssert(combinations.isEmpty)
     }
 
+  func testCombinationsOfVeryLongLength() {
+    var combinations = [1, 2, 3, 4, 5, 6, 7, 8].lazy.combinations(length: 8, repeatingElements: false)
+    let repeats = 1
+    for _ in 1 ... repeats {
+      XCTAssert(combinations.next() != nil )
+    }
+    XCTAssert(combinations.next() == nil)
+  }
+
     func testCombinationsEmpty() {
         let combinations = [].combinations(length: 1, repeatingElements: false)
         XCTAssert(combinations.isEmpty)

--- a/Sources/Combinations.swift
+++ b/Sources/Combinations.swift
@@ -74,15 +74,17 @@ public struct Combinations<S: Sequence>: IteratorProtocol, Sequence {
     }
 
     public mutating func next() -> [S.Iterator.Element]? {
+      while true {
         guard let indices = indicesIterator.next() else {
             return nil
         }
 
         guard indices.sorted() == indices else {
-            return next()
+            continue
         }
 
         let combination = indices.map { values[$0] }
         return combination.isEmpty ? nil : combination
+      }
     }
 }

--- a/Sources/Compress.swift
+++ b/Sources/Compress.swift
@@ -39,14 +39,16 @@ public struct Compressor<S1: Sequence, S2: Sequence>: IteratorProtocol, Sequence
     }
 
     public mutating func next() -> S1.Iterator.Element? {
+      while true {
         guard let nextData = dataIterator.next(), let nextSelector = selectorIterator.next() else {
             return nil
         }
 
         guard nextSelector else {
-            return next()
+            continue
         }
 
         return nextData
+      }
     }
 }

--- a/Sources/Permutations.swift
+++ b/Sources/Permutations.swift
@@ -76,17 +76,19 @@ public struct Permutations<S: Sequence>: IteratorProtocol, Sequence {
     }
 
     public mutating func next() -> [S.Iterator.Element]? {
+      while true {
         guard let indices = indicesIterator.next() else {
             return nil
         }
 
         if !repeatingElements {
             guard Set(indices).count == permutationLength else {
-                return next()
+                continue
             }
         }
 
         let permutation = indices.map { values[$0] }
         return permutation.isEmpty ? nil : permutation
+      }
     }
 }

--- a/Sources/Product.swift
+++ b/Sources/Product.swift
@@ -119,6 +119,7 @@ public struct MixedTypeCartesianProduct<S1: Sequence, S2: Sequence>: IteratorPro
     }
 
     public mutating func next() -> (S1.Iterator.Element, S2.Iterator.Element)? {
+      while true {
         // Avoid stack overflow
         guard secondSequence.underestimatedCount > 0 else {
             return nil
@@ -131,9 +132,10 @@ public struct MixedTypeCartesianProduct<S1: Sequence, S2: Sequence>: IteratorPro
         guard let secondElement = secondIterator.next() else {
             currentFirstElement = firstIterator.next()
             secondIterator = secondSequence.makeIterator()
-            return next()
+            continue
         }
 
         return (firstElement, secondElement)
+      }
     }
 }


### PR DESCRIPTION
Hi Michael (or is it Mike!)
I was working on some swift that does combinations & permutations.
I then discovered itertools in python and then found this repo.
Great that you've done this.
I wanted to check how it handled larger arrays.
I found it crashed if I went up to a combination of 8 elements.
This pull request shows the test that crashes and a fix.
The problem was that in 4 places in the code you have next() as recursive and when arrays get large this fills up the stack (or maybe it's the heap? !).  The solution is to put a while true { } loop in the routine and use continue.  This stops the stack (heap?) being used and it's fine.
